### PR TITLE
Fix for incorrect kernel version reference

### DIFF
--- a/install
+++ b/install
@@ -129,7 +129,7 @@ distro=""
     distro="centos-6"
     initrd_path="bin sbin usr/bin usr/sbin"
     kernel_version=$(uname -r)
-    if [ -f /boot/initramfs-$kernel ]
+    if [ -f /boot/initramfs-${kernel_version}.img ]
     then
       initrd="/boot/initramfs-$(uname -r).img"
       kernel="/boot/vmlinuz-$(uname -r)"


### PR DESCRIPTION
The install script fails after upgrading a host and installing a new kernel. The current test for a kernel version is incorrect and will always fail since the $kernel variable is invalid .. I assume this line should have been using ${kernel_version} as this is set in the pervious line. The script works correctly after making this change.
